### PR TITLE
make rspec/yard optional for deployments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,11 +8,7 @@ Rails.application.load_tasks
 require 'rake'
 require 'bundler'
 
-require 'rspec/core/rake_task'
-require 'yard'
-require 'yard/rake/yardoc_task'
-
-# Executed by the following command 
+# Executed by the following command
 # cd /opt/app/was/was-thumbnail-service/current && bundle exec rake RAILS_ENV=production was_thumbnail_service:run_thumbnail_monitor
 namespace :was_thumbnail_service do
   task run_thumbnail_monitor: :environment do
@@ -24,7 +20,7 @@ end
 namespace :was_thumbnail_service do
   task install_phantomJS: :environment do
     puts "Ensure PhatonmJS is installed"
-    Phantomjs.path 
+    Phantomjs.path
   end
 end
 
@@ -36,19 +32,27 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 
-task :default => :ci  
+task :default => :ci
 
-desc "run continuous integration suite (tests, coverage, docs)" 
+desc "run continuous integration suite (tests, coverage, docs)"
 task :ci => [:rspec, :doc]
 
-task :spec => :rspec
+begin
+  require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:rspec) do |spec|
-  spec.rspec_opts = ["-c", "-f progress", "--tty", "-r ./spec/spec_helper.rb"]
+  task :spec => :rspec
+
+  RSpec::Core::RakeTask.new(:rspec) do |spec|
+    spec.rspec_opts = ["-c", "-f progress", "--tty", "-r ./spec/spec_helper.rb"]
+  end
+rescue LoadError
 end
 
 # Use yard to build docs
 begin
+  require 'yard'
+  require 'yard/rake/yardoc_task'
+
   project_root = File.expand_path(File.dirname(__FILE__))
   doc_dest_dir = File.join(project_root, 'doc')
 
@@ -62,4 +66,4 @@ rescue LoadError
   task :doc do
     abort "Please install the YARD gem to generate rdoc."
   end
-end  
+end


### PR DESCRIPTION
Fixes this error on deploy:

```
Tasks: TOP => deploy:assets:precompile
(See full trace by running task with --trace)
The deploy has failed with an error: Exception while executing as was@was-thumbnail-dev.stanford.edu: rake exit status: 1
rake stdout: Nothing written
rake stderr: rake aborted!
LoadError: cannot load such file -- rspec/core/rake_task
```