### PR TITLE
add initializer to stop delayed_job log diarrhea in dev and test

### DIFF
--- a/config/initializers/delayed_job_silencer.rb
+++ b/config/initializers/delayed_job_silencer.rb
@@ -1,0 +1,21 @@
+# from http://stackoverflow.com/questions/20081186/how-to-ignore-delayed-job-query-logging-in-development-on-rails
+if %w(development test).include? Rails.env
+  module Delayed
+    module Backend
+      module ActiveRecord
+        class Job
+          class << self
+            alias reserve_original reserve
+            def reserve(worker, max_run_time = Worker.max_run_time)
+              previous_level = ::ActiveRecord::Base.logger.level
+              ::ActiveRecord::Base.logger.level = Logger::WARN if previous_level < Logger::WARN
+              value = reserve_original(worker, max_run_time)
+              ::ActiveRecord::Base.logger.level = previous_level
+              value
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #59

Solution from http://stackoverflow.com/questions/20081186/how-to-ignore-delayed-job-query-logging-in-development-on-rails

which refers to same solution here https://github.com/collectiveidea/delayed_job/issues/477