### PR TITLE
Fix invalid utf8 memento text

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
     mime-types (2.99.3)
     mini_exiftool (2.8.0)
     mini_magick (4.5.1)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
     multi_json (1.12.1)
     mysql2 (0.3.21)
@@ -143,8 +143,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
     netrc (0.11.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     okcomputer (1.14.2)
     parser (2.3.1.2)
       ast (~> 2.2)
@@ -322,4 +322,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/lib/was/thumbnail_service/synchronization/memento_database_handler.rb
+++ b/lib/was/thumbnail_service/synchronization/memento_database_handler.rb
@@ -35,9 +35,9 @@ module Was
 
         def compute_simhash_value(memento_text)
           if memento_text.present?
-            return memento_text.force_encoding('UTF-8').simhash(:preserve_punctuation => true, :stop_words => false)
+            memento_text.simhash(:preserve_punctuation => true, :stop_words => false)
           else
-            return 0
+            0
           end
         end
 
@@ -51,7 +51,7 @@ module Was
           begin
             # NOTE:  these timeouts don't work - wrong
             # response = RestClient.get(memento_uri_unwritten, :timeout => 60, :open_timeout => 60)
-            RestClient.get(memento_uri_unwritten)
+            RestClient.get(memento_uri_unwritten).encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
 
             # NOTE:  if the url gives a 302 to the original, non-wayback url, then who is to say that page still is extant?
             #   and then the 302 becomes a 404, which blows up here.

--- a/lib/was/thumbnail_service/synchronization/memento_database_handler.rb
+++ b/lib/was/thumbnail_service/synchronization/memento_database_handler.rb
@@ -11,10 +11,10 @@ module Was
         def add_memento_to_database_timemap
           memento_text = download_memento_text
           @simhash_value = compute_simhash_value(memento_text)
-          insert_memento_into_databse
+          insert_memento_into_database
         end
 
-        def insert_memento_into_databse
+        def insert_memento_into_database
           unless  @uri_id.present? &&  @memento_uri.present? && @memento_datetime.present? &&
                    !@simhash_value.nil? && @simhash_value > 0
 

--- a/spec/was/thumbnail_service/synchronization/memento_database_handler_spec.rb
+++ b/spec/was/thumbnail_service/synchronization/memento_database_handler_spec.rb
@@ -19,41 +19,41 @@ describe Was::ThumbnailService::Synchronization::MementoDatabaseHandler do
       m_db_handler = MementoDatabaseHandler.new(nil, 'https://swap.stanford.edu/20120101120000/http://test1.edu/', 'Mon, 23 Nov 2001 12:00:00')
       allow(m_db_handler).to receive(:download_memento_text).and_return('text')
       allow(m_db_handler).to receive(:compute_simhash_value).and_return(1)
-      allow(m_db_handler).to receive(:insert_memento_into_databse)
+      allow(m_db_handler).to receive(:insert_memento_into_database)
 
       expect(m_db_handler).to receive(:download_memento_text)
       expect(m_db_handler).to receive(:compute_simhash_value).with('text')
-      expect(m_db_handler).to receive(:insert_memento_into_databse)
+      expect(m_db_handler).to receive(:insert_memento_into_database)
       m_db_handler.add_memento_to_database_timemap
       expect(m_db_handler.instance_variable_get(:@simhash_value)).to eq(1)
     end
   end
 
-  describe '.insert_memento_into_databse' do
+  describe '.insert_memento_into_database' do
     it 'should raise an error if any required fields is missing' do
        m_db_handler = MementoDatabaseHandler.new(nil, 'https://swap.stanford.edu/20120101120000/http://test1.edu/', 'Mon, 23 Nov 2001 12:00:00')
        m_db_handler.instance_variable_set(:@simhash_value,'1234')
-       expect{m_db_handler.insert_memento_into_databse}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
+       expect{m_db_handler.insert_memento_into_database}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
 
        m_db_handler = MementoDatabaseHandler.new(1, '', 'Mon, 23 Nov 2001 12:00:00')
        m_db_handler.instance_variable_set(:@simhash_value,'1234')
-       expect{m_db_handler.insert_memento_into_databse}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
+       expect{m_db_handler.insert_memento_into_database}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
 
        m_db_handler = MementoDatabaseHandler.new(1, 'https://swap.stanford.edu/20120101120000/http://test1.edu/', '')
        m_db_handler.instance_variable_set(:@simhash_value,'1234')
-       expect{m_db_handler.insert_memento_into_databse}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
+       expect{m_db_handler.insert_memento_into_database}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
 
        m_db_handler = MementoDatabaseHandler.new(1, 'https://swap.stanford.edu/20120101120000/http://test1.edu/', 'Mon, 23 Nov 2001 12:00:00')
-       expect{m_db_handler.insert_memento_into_databse}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
+       expect{m_db_handler.insert_memento_into_database}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
 
        m_db_handler = MementoDatabaseHandler.new(1, 'https://swap.stanford.edu/20120101120000/http://test1.edu/', 'Mon, 23 Nov 2001 12:00:00')
        m_db_handler.instance_variable_set(:@simhash_value,0)
-       expect{m_db_handler.insert_memento_into_databse}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
+       expect{m_db_handler.insert_memento_into_database}.to raise_error(RuntimeError, /^Memento insert is missing required fields/)
     end
     it 'should insert memento into the database', :mysql do
        m_db_handler = MementoDatabaseHandler.new(9999, 'https://swap.stanford.edu/20120101120000/http://test2.edu/', 'Mon, 23 Nov 2001 12:00:00')
        m_db_handler.instance_variable_set(:@simhash_value,9342137274140115447)
-       m_db_handler.insert_memento_into_databse
+       m_db_handler.insert_memento_into_database
 
        @test_memento = Memento.find_by( memento_uri: 'https://swap.stanford.edu/20120101120000/http://test2.edu/')
        expect(@test_memento[:uri_id]).to eq(9999)


### PR DESCRIPTION
This fixes errors such as:

(from the Rails logs)
```
E, [2017-10-09T23:38:11.097236 #17718] ERROR -- : Error in inserting memento #<Was::ThumbnailService::Synchronization::MementoDatabaseHandler:0x000000054f4d18 @uri_id=282, @memento_uri="https://swap.stanford.edu/20160322205517/http://www.depv.org/", @memento_datetime="20160322205517"> into database.
invalid byte sequence in UTF-8
```

About the problem:  we have WARC files served by our SWAP machine that have invalid UTF-8 in them, presumably because the original web servers from which the data were harvested were not configured properly to serve valid UTF-8.  

The change in commit 26a109f replaces invalid or undefined UTF-8 bytes from our WARCs (as retrieved from SWAP for thumbnail generation) with an empty string.  This should cut down on the annoying UTF-8 problems, which was one of the causes of the noisy errors for honeybadger that were removed from Honeybadger reporting with #74.

The nokogiri update was required to pass bundler audit, and the typo was just ... something I couldn't stand.

connected to #57