### PR TITLE
Remove therubyracer in favor of nodejs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'jbuilder', '~> 2.0'
 gem 'rest-client', '~> 1.8' # pinned to 1.x release line as 2.x breaks rake was_thumbnail_service:run_thumbnail_monitor
 gem 'simhash' # to compare mementos
 
-gem 'therubyracer' # embed the V8 JavaScript interpreter into Ruby
 gem 'phantomjs' # headless WebKit scriptable with a JavaScript API
 gem 'uglifier' # js compression
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
-    libv8 (3.16.14.19)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -183,7 +182,6 @@ GEM
     rainbow (3.0.0)
     rake (12.3.1)
     rdoc (6.0.4)
-    ref (2.0.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -250,9 +248,6 @@ GEM
       net-ssh (>= 2.8.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (1.4.1)
@@ -312,7 +307,6 @@ DEPENDENCIES
   simhash
   spring
   sqlite3
-  therubyracer
   turbolinks
   uglifier
   vcr
@@ -320,4 +314,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
therubyracer has been abandoned by Rails: https://github.com/rails/rails/pull/29285
It is no longer compatible with the latest version of
autoprefixer-rails: https://github.com/ai/autoprefixer-rails/issues/137