### PR TITLE
Update the rest-client to 2.0 to fix cipher not found error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 
-gem 'rest-client', '~> 2.0' # '~> 1.8' # pinned to 1.x release line as 2.x breaks rake was_thumbnail_service:run_thumbnail_monitor
+gem 'rest-client', '~> 2.0'
 gem 'simhash' # to compare mementos
 
 gem 'phantomjs' # headless WebKit scriptable with a JavaScript API

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 
-gem 'rest-client', '~> 1.8' # pinned to 1.x release line as 2.x breaks rake was_thumbnail_service:run_thumbnail_monitor
+gem 'rest-client', '~> 2.0' # '~> 1.8' # pinned to 1.x release line as 2.x breaks rake was_thumbnail_service:run_thumbnail_monitor
 gem 'simhash' # to compare mementos
 
 gem 'phantomjs' # headless WebKit scriptable with a JavaScript API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,10 +199,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rest-client (1.8.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -320,7 +320,7 @@ DEPENDENCIES
   rails (~> 5.0.7)
   rails-controller-testing
   responders
-  rest-client (~> 1.8)
+  rest-client (~> 2.0)
   rspec-rails
   rubocop (~> 0.53.0)
   sass-rails (~> 5.0)


### PR DESCRIPTION
Note: I'm happy to remove the inline comment here at Gemfile:12, just holding it until we're sure this change is OK. The original note says that pinning rest-client to 1.8 because of errors in `rake was_thumbnail_service:run_thumbnail_monitor` however I was unable to get the tests to run against 1.8.