### PR TITLE
Use Faraday instead of RestClient

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
 gem 'turbolinks'
 
-gem 'rest-client', '~> 2.0'
+gem 'faraday'
 gem 'simhash' # to compare mementos
 
 gem 'phantomjs' # headless WebKit scriptable with a JavaScript API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,8 +117,6 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.1)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
     druid-tools (1.0.0)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
@@ -149,14 +147,14 @@ GEM
       dry-types (~> 0.13.1)
     erubi (1.7.1)
     execjs (2.7.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     fastimage (2.1.5)
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.7)
     honeybadger (4.1.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
     i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.8.0)
@@ -183,11 +181,11 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
+    multipart-post (2.0.0)
     mysql2 (0.5.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
-    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.9.0)
       mini_portile2 (~> 2.4.0)
@@ -239,10 +237,6 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rest-client (2.0.2)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -316,9 +310,6 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.5)
     unicode (0.4.4.4)
     unicode-display_width (1.4.0)
     vcr (4.0.0)
@@ -350,6 +341,7 @@ DEPENDENCIES
   delayed_job_active_record
   dlss-capistrano
   druid-tools
+  faraday
   fastimage
   honeybadger
   jbuilder (~> 2.0)
@@ -361,7 +353,6 @@ DEPENDENCIES
   rails (~> 5.2.2)
   rails-controller-testing
   responders
-  rest-client (~> 2.0)
   rspec-rails
   rubocop (~> 0.53.0)
   sass-rails (~> 5.0)

--- a/lib/was/thumbnail_service/synchronization/timemap_wayback_parser.rb
+++ b/lib/was/thumbnail_service/synchronization/timemap_wayback_parser.rb
@@ -20,7 +20,9 @@ module Was
           timemap_uri = "#{Settings.wayback_timemap_uri}#{@uri}"
 
           begin
-            RestClient.get(timemap_uri, timeout: 60, open_timeout: 60)
+            response = Faraday.get(timemap_uri)
+            raise "#{response.reason_phrase}: #{response.status}" unless response.success?
+            response.body
           rescue StandardError => e
             Honeybadger.notify e, context: { timemap_uri: timemap_uri }
             Rails.logger.error { "Error in retrieving the timemap from #{timemap_uri}.\n#{e.message}\n#{e.backtrace}" }

--- a/spec/was/thumbnail_service/synchronization/memento_database_handler_spec.rb
+++ b/spec/was/thumbnail_service/synchronization/memento_database_handler_spec.rb
@@ -99,7 +99,7 @@ describe Was::ThumbnailService::Synchronization::MementoDatabaseHandler do
     it 'should raise an error for non-available memento' do
       VCR.use_cassette('test1_notavailable') do
         m_db_handler = MementoDatabaseHandler.new(1, 'https://swap.stanford.edu/20120101120000/http://test2.edu/', '')
-        expect { m_db_handler.download_memento_text }.to raise_error(RuntimeError, /RestClient error downloading memento text/)
+        expect { m_db_handler.download_memento_text }.to raise_error(RuntimeError, /error downloading memento text/)
       end
     end
     it 'should return an emtpy string for not-valid memento' do


### PR DESCRIPTION
This is a late-in-the-day attempt to work around RestClient errors in production. Most of our infra already uses Faraday, and this aligns was-thumbnail-service with other codebases.