### PR TITLE
tell coveralls it's a rails app

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,6 @@
 require File.expand_path('../config/environment', __dir__)
 
 require 'coveralls'
-Coveralls.wear!
+Coveralls.wear!('rails')
 
 require 'vcr'


### PR DESCRIPTION
## Why was this change made?

Telling coveralls it's a Rails app means it will give more accurate stats on code coverage.

## Was the documentation updated?

N/A