### PR TITLE
Removes trailing whitespace in order to avoid BadURI errors

### DIFF
--- a/lib/was/thumbnail_service/monitor.rb
+++ b/lib/was/thumbnail_service/monitor.rb
@@ -7,7 +7,7 @@ module Was
         seed_uris = SeedUri.all
 
         seed_uris.each do |seed_uri|
-          uri = seed_uri[:uri]
+          uri = seed_uri[:uri].strip
           uri_id = seed_uri[:id]
 
           mementos_db_count = count_mementos_in_database uri_id


### PR DESCRIPTION
Fixes #75 

https://app.honeybadger.io/projects/51217/faults/43391149

The error above is avoided by removing the trailing whitespace in the URI:

Before:

```
irb(main):002:0> Faraday.get('https://swap.stanford.edu/timemap/link/http://blog.sina.com.cn/txxwjy/ ')
Traceback (most recent call last):
       14: from /Users/sul.amcollie/.rbenv/versions/2.6.3/bin/irb:23:in `<main>'
       13: from /Users/sul.amcollie/.rbenv/versions/2.6.3/bin/irb:23:in `load'
       12: from /Users/sul.amcollie/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/irb-
...
...
...
URI::InvalidURIError (bad URI(is not URI?): "https://swap.stanford.edu/timemap/link/http://blog.sina.com.cn/txxwjy/ ")
```

After:

```
irb(main):003:0> Faraday.get('https://swap.stanford.edu/timemap/link/http://blog.sina.com.cn/txxwjy/')
=> #<Faraday::Response:0x00007fb76ca1da80 @on_complete_callbacks=[], @env=#<Faraday::Env @method=:get @body="<http://blog.sina.com.cn/txxwjy/>; rel=\"original\",
...
...
...
@status=200 @reason_phrase="OK">>
```