### PR TITLE
raised error message includes timemap_uri

### DIFF
--- a/lib/was/thumbnail_service/synchronization/timemap_wayback_parser.rb
+++ b/lib/was/thumbnail_service/synchronization/timemap_wayback_parser.rb
@@ -21,7 +21,7 @@ module Was
 
           begin
             response = Faraday.get(timemap_uri)
-            raise "#{response.reason_phrase}: #{response.status}" unless response.success?
+            raise "#{response.reason_phrase}: #{response.status} for #{timemap_uri}" unless response.success?
             response.body
           rescue StandardError => e
             Honeybadger.notify e, context: { timemap_uri: timemap_uri }


### PR DESCRIPTION
## Why was this change made?

To make it easier to see if we are always failing on the same URLs:

Here:

![image](https://user-images.githubusercontent.com/96775/73220183-b9c2f580-4112-11ea-9226-b87e5d60655a.png)

vs. scrolling down to here:

![image](https://user-images.githubusercontent.com/96775/73220220-c5162100-4112-11ea-830d-46e3b58ec697.png)

## Was the usage documentation (e.g. wiki, README, queue or DB specific README) updated?

n/a