### PR TITLE
resize failures get more context info

### DIFF
--- a/lib/was/thumbnail_service/capture/capture_thumbnail.rb
+++ b/lib/was/thumbnail_service/capture/capture_thumbnail.rb
@@ -69,6 +69,13 @@ module Was
                              end
           image.resize resize_dimension
           image.write(temporary_image)
+        rescue StandardError => e
+          Honeybadger.notify e, context: Honeybadger.get_context.merge(
+            memento_uri: @memento_uri,
+            memento_datetime: @memento_datetime,
+            temp_image_loc: @temporary_file
+          )
+          Rails.logger.error { "Error resizing temporary image for #{@druid_id} at #{@temporary_file} for uri #{@memento_uri}.\n#{e.message}\n#{e.backtrace}" }
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

To get a little more info in honeybadger for these:

![image](https://user-images.githubusercontent.com/96775/73221201-23dc9a00-4115-11ea-978a-44f4cb1dda11.png)

which have some info in context (but I want more!)

![image](https://user-images.githubusercontent.com/96775/73221235-32c34c80-4115-11ea-8f38-a035bb612944.png)


## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?

n/a