### PR TITLE
Added custom job_type to prevent deprecated emails

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+job_type :no_warnings_rake, "cd :path && :environment_variable=:environment RUBYOPT='-W0' bundle exec rake :task --silent :output"
+
 every 30.minutes do
-  rake 'was_thumbnail_service:run_thumbnail_monitor'
+  no_warnings_rake 'was_thumbnail_service:run_thumbnail_monitor'
 end


### PR DESCRIPTION
## Why was this change made?
To reduce deprecated warning emails


## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?
n/a


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
