### PR TITLE
unpin rack to allow upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'mysql2', '< 0.5.3' # because incompatible w/ MySQL we have deployed (5.1)
-gem 'rack', '~> 2.0.8' # pending https://github.com/sportngin/okcomputer/pull/161
 gem 'rails', '~> 5.2.2'
 gem 'responders' # controller-level `respond_to' feature now in `responders` gem as of rails 4.2
 gem 'sass-rails', '~> 5.0' # use SCSS as CSS preprocessor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     phantomjs (2.1.1.0)
     powerpack (0.1.2)
     public_suffix (4.0.5)
-    rack (2.0.9)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.3)
@@ -373,7 +373,6 @@ DEPENDENCIES
   mysql2 (< 0.5.3)
   okcomputer
   phantomjs
-  rack (~> 2.0.8)
   rails (~> 5.2.2)
   rails-controller-testing
   responders


### PR DESCRIPTION
## Why was this change made?

* the bug for which version was pinned has been addressed
* this upgrade allows us to address CVE-2020-8161 and CVE-2020-8184


## How was this change tested?

unit tests


## Which documentation and/or configurations were updated?

just a dependency update