### PR TITLE
Disable cron in preparation to decommission

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,6 +2,6 @@
 
 job_type :no_warnings_rake, "cd :path && :environment_variable=:environment RUBYOPT='-W0' bundle exec rake :task --silent :output"
 
-every 30.minutes do
-  no_warnings_rake 'was_thumbnail_service:run_thumbnail_monitor'
-end
+# every 30.minutes do
+#  no_warnings_rake 'was_thumbnail_service:run_thumbnail_monitor'
+# end


### PR DESCRIPTION
## Why was this change made?

This service is to be decommissioned.  This will clear out the crontab

## How was this change tested?



## Which documentation and/or configurations were updated?



