### PR TITLE
Switch back to a released version of honeybadger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,7 @@ gem 'whenever', require: false
 
 gem 'config'
 gem 'druid-tools'
-# gem 'honeybadger', '~> 4.2' # for exception reporting
-# See https://github.com/honeybadger-io/honeybadger-ruby/issues/369
-gem 'honeybadger', github: 'honeybadger-io/honeybadger-ruby', branch: 'avoid-ar-connections'
-
+gem 'honeybadger', '~> 4.2' # for exception reporting
 gem 'okcomputer' # for 'upness' monitoring
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/honeybadger-io/honeybadger-ruby.git
-  revision: 6e1b826891b9a50f089ffa0d6018cdf269050c2b
-  branch: avoid-ar-connections
-  specs:
-    honeybadger (4.7.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -182,6 +175,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
+    honeybadger (4.7.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -372,7 +366,7 @@ DEPENDENCIES
   druid-tools
   faraday
   fastimage
-  honeybadger!
+  honeybadger (~> 4.2)
   jbuilder (~> 2.0)
   jquery-rails
   mini_magick


### PR DESCRIPTION


## Why was this change made?

https://github.com/honeybadger-io/honeybadger-ruby/issues/369 has been resolved

## How was this change tested?



## Which documentation and/or configurations were updated?



